### PR TITLE
Add changelog document

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+Add a new line detailing community additions to crowdin translations. Then create a pull request.
+
+* 13.03.2020 - Added Greek community translations


### PR DESCRIPTION
There is currently no mechanism for kicking off new builds for
cp-translations when community translations are updated.

Adding a changelog should allow translation team to easily create a new
pull request when they know translations need to be added.

This will start the build process and allow us to deploy.