### PR TITLE
Add strings for registrations to covid banner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,4 +5,4 @@ Add a new line detailing community additions to crowdin translations. Then creat
 * 13.03.2020 - Added Greek community translations
 * 16.03.2020 - Fix broken templating for Dutch session cancelled email translations.
 * 17.04.2020 - Add strings for Covid Banner
-* 01.05.2020 - Update strings for Covid banner
+* 01.05.2020 - Add registration strings for Covid banner

--- a/changelog.md
+++ b/changelog.md
@@ -5,3 +5,4 @@ Add a new line detailing community additions to crowdin translations. Then creat
 * 13.03.2020 - Added Greek community translations
 * 16.03.2020 - Fix broken templating for Dutch session cancelled email translations.
 * 17.04.2020 - Add strings for Covid Banner
+* 01.05.2020 - Update strings for Covid banner

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-translations",
-  "version": "1.0.143",
+  "version": "1.0.142",
   "description": "Translations for the CoderDojo Community Platform",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-translations",
-  "version": "1.0.142",
+  "version": "1.0.143",
   "description": "Translations for the CoderDojo Community Platform",
   "main": "index.js",
   "scripts": {

--- a/strings/en_US/messages.po
+++ b/strings/en_US/messages.po
@@ -4498,3 +4498,13 @@ msgstr "Digital Making at Home"
 
 msgid "from the Raspberry Pi Foundation."
 msgstr "from the Raspberry Pi Foundation."
+
+msgid "There are still many ways for you to get involved in the Raspberry Pi community! Please"
+msgstr "There are still many ways for you to get involved in the Raspberry Pi community! Please"
+
+msgid "register your details"
+msgstr "register your details"
+
+msgid "with us so we can find out how best to support you."
+msgstr "with us so we can find out how best to support you."
+

--- a/strings/en_US/messages.po
+++ b/strings/en_US/messages.po
@@ -4507,4 +4507,3 @@ msgstr "register your details"
 
 msgid "with us so we can find out how best to support you."
 msgstr "with us so we can find out how best to support you."
-

--- a/strings/en_US/messages.po
+++ b/strings/en_US/messages.po
@@ -4499,8 +4499,8 @@ msgstr "Digital Making at Home"
 msgid "from the Raspberry Pi Foundation."
 msgstr "from the Raspberry Pi Foundation."
 
-msgid "There are still many ways for you to get involved in the Raspberry Pi community! Please"
-msgstr "There are still many ways for you to get involved in the Raspberry Pi community! Please"
+msgid "There are still many ways for you to get involved in the CoderDojo community! Please"
+msgstr "There are still many ways for you to get involved in the CoderDojo community! Please"
 
 msgid "register your details"
 msgstr "register your details"


### PR DESCRIPTION
Original copy [in google docs](https://docs.google.com/document/d/12zaaWIFXIdd0hv4atNRRX1XsgxGqUcgytxWiLExITyE/edit)